### PR TITLE
Revert timeFilter to being inclusive like BETWEEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Macro example                                          | Description
 ------------------------------------------------------ | -------------
 `$__time(dateColumn)`                                  | Will be replaced by an expression to convert to a UNIX timestamp and rename the column to `time`. For example, *TRY_TO_TIMESTAMP(dateColumn) as time*
 `$__timeEpoch(dateColumn)`                             | Will be replaced by an expression to convert to a UNIX timestamp and rename the column to `time`.
-`$__timeFilter(dateColumn)`                            | Will be replaced by a time range filter using the specified column name. For example, *CONVERT_TIMEZONE('UTC', 'UTC', time) < '2022-09-24T12:13:14Z' AND CONVERT_TIMEZONE('UTC', 'UTC', time) > '2022-09-25T12:13:14Z*
-`$__timeFilter(dateColumn, timezone)`                  | Will be replaced by a time range filter using the specified column name. For example, *CONVERT_TIMEZONE('UTC', 'America/New_York', time) < '2022-09-24T12:13:14Z' AND CONVERT_TIMEZONE('UTC', 'America/New_York', time) > '2022-09-25T12:13:14Z*
+`$__timeFilter(dateColumn)`                            | Will be replaced by a time range filter using the specified column name. For example, *dateColumn BETWEEN 1494410783 AND 1494410983*
+`$__timeFilter(dateColumn, timezone)`                  | Will be replaced by a time range filter using the specified column name. For example, *CONVERT_TIMEZONE('UTC', 'America/New_York', time) >= '2022-09-24T12:13:14Z' AND CONVERT_TIMEZONE('UTC', 'America/New_York', time) <= '2022-09-25T12:13:14Z*
 `$__timeFrom()`                                        | Will be replaced by the start of the currently active time selection. For example, *1494410783*
 `$__timeTo()`                                          | Will be replaced by the end of the currently active time selection. For example, *1494410983*
 `$__timeGroup(dateColumn,'5m')`                        | Will be replaced by an expression usable in GROUP BY clause. For example, *floor(extract(epoch from dateColumn)/120)*120*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "michelin-snowflake-datasource",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Data source for Snowflake",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/pkg/macros.go
+++ b/pkg/macros.go
@@ -90,10 +90,13 @@ func evaluateMacro(name string, args []string, configStruct *queryConfigStruct) 
 		}
 		column := args[0]
 		timezone := "'UTC'"
-		if len(args) > 1 {
+		if len(args) == 1 {
+			return fmt.Sprintf("%s BETWEEN '%s' AND '%s'", args[0], timeRange.From.UTC().Format(time.RFC3339Nano), timeRange.To.UTC().Format(time.RFC3339Nano)), nil
+		} else {
 			timezone = args[1]
+			return fmt.Sprintf("CONVERT_TIMEZONE('UTC', %s, %s) >= '%s' AND CONVERT_TIMEZONE('UTC', %s, %s) <= '%s'", timezone, column, timeRange.From.UTC().Format(time.RFC3339Nano), timezone, column, timeRange.To.UTC().Format(time.RFC3339Nano)), nil
 		}
-		return fmt.Sprintf("CONVERT_TIMEZONE('UTC', %s, %s) > '%s' AND CONVERT_TIMEZONE('UTC', %s, %s) < '%s'", timezone, column, timeRange.From.UTC().Format(time.RFC3339Nano), timezone, column, timeRange.To.UTC().Format(time.RFC3339Nano)), nil
+
 	case "__timeFrom":
 		return fmt.Sprintf("'%s'", timeRange.From.UTC().Format(time.RFC3339Nano)), nil
 	case "__timeTo":

--- a/pkg/macros_test.go
+++ b/pkg/macros_test.go
@@ -36,8 +36,8 @@ func TestEvaluateMacro(t *testing.T) {
 		{name: "__timeEpoch", args: []string{"col"}, response: "extract(epoch from col) as time"},
 		// __timeFilter
 		{name: "__timeFilter", args: []string{}, err: "missing time column argument for macro __timeFilter"},
-		{name: "__timeFilter", args: []string{"col"}, config: configStruct, response: "CONVERT_TIMEZONE('UTC', 'UTC', col) > '" + timeRange.From.UTC().Format(time.RFC3339Nano) + "' AND CONVERT_TIMEZONE('UTC', 'UTC', col) < '" + timeRange.To.UTC().Format(time.RFC3339Nano) + "'"},
-		{name: "__timeFilter", args: []string{"col", "'America/New_York'"}, config: configStruct, response: "CONVERT_TIMEZONE('UTC', 'America/New_York', col) > '" + timeRange.From.UTC().Format(time.RFC3339Nano) + "' AND CONVERT_TIMEZONE('UTC', 'America/New_York', col) < '" + timeRange.To.UTC().Format(time.RFC3339Nano) + "'"},
+		{name: "__timeFilter", args: []string{"col"}, config: configStruct, response: "col BETWEEN '" + timeRange.From.UTC().Format(time.RFC3339Nano) + "' AND '" + timeRange.To.UTC().Format(time.RFC3339Nano) + "'"},
+		{name: "__timeFilter", args: []string{"col", "'America/New_York'"}, config: configStruct, response: "CONVERT_TIMEZONE('UTC', 'America/New_York', col) >= '" + timeRange.From.UTC().Format(time.RFC3339Nano) + "' AND CONVERT_TIMEZONE('UTC', 'America/New_York', col) <= '" + timeRange.To.UTC().Format(time.RFC3339Nano) + "'"},
 		// __timeFrom
 		{name: "__timeFrom", args: []string{}, config: configStruct, response: "'" + timeRange.From.UTC().Format(time.RFC3339Nano) + "'"},
 		// __timeTo


### PR DESCRIPTION
### Problem
I noticed a weird behaviour with the date picker and Snowflake. If you pick a particular date (e.g. Feb 12th) the Snowflake plugin doesn't include any rows with that exact date/datetime. I noticed the Snowflake plugin's docs have a different description for $__timeFilter(dateColumn) than Grafana does for Postgres and MySQL.

| Adapter | Description |
| --- | --- |
| [Grafana for Postgres and MySQL](https://grafana.com/docs/grafana/latest/datasources/postgres/) | `Will be replaced by a time range filter using the specified column name. For example, dateColumn BETWEEN FROM_UNIXTIME(1494410783) AND FROM_UNIXTIME(1494410983)` |
| [Snowflake plugin](https://github.com/michelin/snowflake-grafana-datasource#supported-macros) | `Will be replaced by a time range filter using the specified column name. For example, CONVERT_TIMEZONE('UTC', 'UTC', time) < '2022-09-24T12:13:14Z' AND CONVERT_TIMEZONE('UTC', 'UTC', time) > '2022-09-25T12:13:14Z` |

The plugin [originally](https://github.com/michelin/snowflake-grafana-datasource/blob/3126649a0aa93799d42346278a4f854a8d2f4860/pkg/macros.go#L91) used `BETWEEN`. More recently, https://github.com/michelin/snowflake-grafana-datasource/pull/22 introduced the ability to pass a time zone to `__timeFilter` and in doing so replaced `BETWEEN` with explicit `>` and `<`. Snowflake's logic for [BETWEEN](https://docs.snowflake.com/en/sql-reference/functions/between) uses `>=` and `<=`. I'm not sure if this that was intentional or an oversight.

### Solution
1. In cases where no timezone is provided, use `BETWEEN` just as Grafana suggests. 
2. In cases where a timezone is provided, use the predicates equivalent to `BETWEEN`.
3. Update docs and tests accordingly.